### PR TITLE
git add instruction

### DIFF
--- a/content/posts/go-nix-containers.md
+++ b/content/posts/go-nix-containers.md
@@ -373,9 +373,12 @@ Here's `flake.nix`:
 
 So, we've split the container building code into a separate Nix expression, in a separate file, that accepts the package from the flake through its `packages` argument.
 
+We need to run `git add container.nix` before rebuilding. Nix flakes, when used with Git, are tied to respository state and any extra nix expressions must be included.
+
 Let's check it works:
 
 ```
+$ git add container.n
 $ nix build .#container
 $ docker load < result && docker run --rm example:0.1
 ace5c9ecfd0b: Loading layer  1.341MB/1.341MB

--- a/content/posts/go-nix-containers.md
+++ b/content/posts/go-nix-containers.md
@@ -373,12 +373,10 @@ Here's `flake.nix`:
 
 So, we've split the container building code into a separate Nix expression, in a separate file, that accepts the package from the flake through its `packages` argument.
 
-We need to run `git add container.nix` before rebuilding. Nix flakes, when used with Git, are tied to respository state and any extra nix expressions must be included.
-
 Let's check it works:
 
 ```
-$ git add container.n
+$ git add container.nix
 $ nix build .#container
 $ docker load < result && docker run --rm example:0.1
 ace5c9ecfd0b: Loading layer  1.341MB/1.341MB
@@ -386,6 +384,8 @@ The image example:0.1 already exists, renaming the old one with ID sha256:93d153
 Loaded image: example:0.1
 Hello flake
 ```
+
+(Note that we need to run `git add container.nix` before rebuilding. When nix builds a flake from a Git repository, unstaged Git changes will be ignored).
 
 Good to see it still works!
 


### PR DESCRIPTION
Thank you so much for this guide, it's awesome. 

I hit an issue here when I tried to build after the 'Spring Cleaning' step. I created the `container.nix` file but didn't think to add it to the tracked git files.  This caused the container build to fail 
`error: path '/nix/store/<sha256>-source/container.nix' does not exist`

Adding a little more instruction  for the next nix newbie after me.